### PR TITLE
feat: rasterize town map

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -395,8 +395,9 @@ const App: React.FC = () => {
             break;
         case 'generate_town':
             {
-                const newMapData = generateTownMap(50, 50, gameState.worldSeed);
-                dispatch({ type: 'SET_MAP_DATA', payload: newMapData });
+                // Town map now includes rasterized features and path details
+                const townMapData = generateTownMap(50, 50, gameState.worldSeed);
+                dispatch({ type: 'SET_MAP_DATA', payload: townMapData });
                 dispatch({ type: 'SET_GAME_PHASE', payload: GamePhase.VILLAGE_VIEW });
             }
             break;

--- a/src/services/mapService.ts
+++ b/src/services/mapService.ts
@@ -5,7 +5,8 @@
 import { MapData, MapTile, Location, Biome } from '../types';
 import { STARTING_LOCATION_ID } from '../constants';
 import { SeededRandom } from '../utils/seededRandom';
-import { generateTown, rasterize } from './townGeneratorService';
+import { generateTown } from './townGeneratorService';
+import { rasterizeTownModel } from './townRasterizer';
 
 /**
  * Generates a world map with biomes and links to predefined locations.
@@ -118,5 +119,22 @@ export function generateMap(
 
 export function generateTownMap(rows: number, cols: number, worldSeed: number): MapData {
     const townModel = generateTown(15, worldSeed);
-    return rasterize(townModel, rows, cols);
+    const rasterized = rasterizeTownModel(townModel, rows, cols);
+
+    const tiles: MapTile[][] = rasterized.tileBiomeIds.map((row, y) =>
+        row.map((biomeId, x) => ({
+            x,
+            y,
+            biomeId,
+            discovered: true,
+            isPlayerCurrent: false,
+        }))
+    );
+
+    return {
+        gridSize: { rows, cols },
+        tiles,
+        activeSeededFeatures: rasterized.activeSeededFeatures,
+        pathDetails: rasterized.pathDetails,
+    };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -468,6 +468,8 @@ export interface MapTile {
 export interface MapData {
   gridSize: { rows: number; cols: number };
   tiles: MapTile[][]; // tiles[row][col]
+  activeSeededFeatures?: Array<{ x: number; y: number; config: SeededFeatureConfig; actualSize: number }>;
+  pathDetails?: PathDetails;
 }
 
 export interface GeminiLogEntry {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -385,6 +385,8 @@ export interface MapTile {
 export interface MapData {
   gridSize: { rows: number; cols: number };
   tiles: MapTile[][]; // tiles[row][col]
+  activeSeededFeatures?: Array<{ x: number; y: number; config: SeededFeatureConfig; actualSize: number }>;
+  pathDetails?: PathDetails;
 }
 
 export interface GeminiLogEntry {
@@ -653,6 +655,11 @@ export interface SeededFeatureConfig {
     color?: string;
   };
   zOffset?: number; // For layering, higher zOffset means it draws on top
+}
+
+export interface PathDetails {
+  mainPathCoords: Set<string>;
+  pathAdjacencyCoords: Set<string>;
 }
 
 export interface GlossaryTooltipProps {


### PR DESCRIPTION
## Summary
- derive town maps using `rasterizeTownModel` to expose tile biomes, seeded features, and path details
- extend `MapData` type with optional seeded feature and path detail metadata
- update dev menu town generation to use enriched map data

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688dfc7071a8832f99d9f5deac33915f