### PR TITLE
Use advanced town rasterizer

### DIFF
--- a/src/services/mapService.ts
+++ b/src/services/mapService.ts
@@ -6,7 +6,7 @@ import { MapData, MapTile, Location, Biome } from '../types';
 import { STARTING_LOCATION_ID } from '../constants';
 import { SeededRandom } from '../utils/seededRandom';
 import { generateTown } from './townGeneratorService';
-import { rasterizeTown } from './townRasterizer';
+import { rasterizeTownModel } from './townRasterizer';
 
 /**
  * Generates a world map with biomes and links to predefined locations.
@@ -119,6 +119,22 @@ export function generateMap(
 
 export function generateTownMap(rows: number, cols: number, worldSeed: number): MapData {
     const townModel = generateTown(15, worldSeed);
-    const { mapData } = rasterizeTown(townModel, rows, cols);
-    return mapData;
+    const rasterized = rasterizeTownModel(townModel, rows, cols);
+
+    const tiles: MapTile[][] = rasterized.tileBiomeIds.map((row, y) =>
+        row.map((biomeId, x) => ({
+            x,
+            y,
+            biomeId,
+            discovered: true,
+            isPlayerCurrent: false,
+        }))
+    );
+
+    return {
+        gridSize: { rows, cols },
+        tiles,
+        activeSeededFeatures: rasterized.activeSeededFeatures,
+        pathDetails: rasterized.pathDetails,
+    };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -468,6 +468,8 @@ export interface MapTile {
 export interface MapData {
   gridSize: { rows: number; cols: number };
   tiles: MapTile[][]; // tiles[row][col]
+  activeSeededFeatures?: Array<{ x: number; y: number; config: SeededFeatureConfig; actualSize: number }>;
+  pathDetails?: PathDetails;
 }
 
 export interface GeminiLogEntry {

--- a/src/utils/submapUtils.ts
+++ b/src/utils/submapUtils.ts
@@ -9,7 +9,15 @@ import { LOCATIONS, STARTING_LOCATION_ID, BIOMES } from '../constants';
 import { biomeVisualsConfig, defaultBiomeVisuals } from '../config/submapVisualsConfig';
 
 // --- Hashing ---
-const simpleHash = (worldSeed: number, worldX: number, worldY: number, biomeSeedText: string, submapX: number, submapY: number, seedSuffix: string): number => {
+export const simpleHash = (
+    worldSeed: number,
+    worldX: number,
+    worldY: number,
+    biomeSeedText: string,
+    submapX: number,
+    submapY: number,
+    seedSuffix: string
+): number => {
     let h = 0;
     const str = `${worldSeed},${worldX},${worldY},${submapX},${submapY},${biomeSeedText},${seedSuffix}`;
     for (let i = 0; i < str.length; i++) {


### PR DESCRIPTION
## Summary
- Replace town rasterizer with richer `rasterizeTownModel` including roads, walls, gates, and path adjacency
- Centralize submap hashing and integrate rasterized town data in hooks and map service
- Extend `MapData` to carry seeded features and path details

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688dfafc5d54832fafa140c7a0d49649