### PR TITLE
Use advanced town rasterizer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,7 +36,6 @@ import {
   USE_DUMMY_CHARACTER_FOR_DEV,
   BIOMES,
 } from './constants';
-import { generateTownMap } from './services/mapService';
 import { SUBMAP_DIMENSIONS } from './config/mapConfig';
 
 import WorldPane from './components/WorldPane';
@@ -394,14 +393,10 @@ const App: React.FC = () => {
             processAction({ type: 'TOGGLE_NPC_TEST_MODAL', label: 'Toggle NPC Test Plan' });
             break;
         case 'generate_town':
-            {
-                const newMapData = generateTownMap(50, 50, gameState.worldSeed);
-                dispatch({ type: 'SET_MAP_DATA', payload: newMapData });
-                dispatch({ type: 'SET_GAME_PHASE', payload: GamePhase.VILLAGE_VIEW });
-            }
+            processAction({ type: 'ENTER_TOWN', label: 'Generate Town' });
             break;
     }
-  }, [dispatch, handleNewGame, processAction, handleLoadGameFlow, handleBattleMapDemo, gameState.worldSeed]);
+  }, [dispatch, handleNewGame, processAction, handleLoadGameFlow, handleBattleMapDemo]);
 
   const handleModelChange = useCallback((model: string | null) => {
     dispatch({ type: 'SET_DEV_MODEL_OVERRIDE', payload: model });

--- a/src/hooks/useGameActions.ts
+++ b/src/hooks/useGameActions.ts
@@ -35,6 +35,7 @@ import {
 } from './actions/handleSystemAndUi';
 import { getDiegeticPlayerActionMessage } from '../utils/actionUtils';
 import { getSubmapTileInfo } from '../utils/submapUtils';
+import { generateTownMap } from '../services/mapService';
 
 
 interface UseGameActionsProps {
@@ -136,6 +137,13 @@ export function useGameActions({
             break;
           case 'QUICK_TRAVEL':
             await handleQuickTravel({ action, gameState, dispatch, addMessage });
+            break;
+          case 'ENTER_TOWN':
+            {
+              const newMapData = generateTownMap(50, 50, gameState.worldSeed);
+              dispatch({ type: 'SET_MAP_DATA', payload: newMapData });
+              dispatch({ type: 'SET_GAME_PHASE', payload: GamePhase.VILLAGE_VIEW });
+            }
             break;
           case 'ENTER_VILLAGE':
             dispatch({ type: 'SET_GAME_PHASE', payload: GamePhase.VILLAGE_VIEW });

--- a/src/services/mapService.ts
+++ b/src/services/mapService.ts
@@ -6,7 +6,7 @@ import { MapData, MapTile, Location, Biome } from '../types';
 import { STARTING_LOCATION_ID } from '../constants';
 import { SeededRandom } from '../utils/seededRandom';
 import { generateTown } from './townGeneratorService';
-import { rasterizeTown } from './townRasterizer';
+import { rasterizeTownModel } from './townRasterizer';
 
 /**
  * Generates a world map with biomes and links to predefined locations.
@@ -119,6 +119,22 @@ export function generateMap(
 
 export function generateTownMap(rows: number, cols: number, worldSeed: number): MapData {
     const townModel = generateTown(15, worldSeed);
-    const { mapData } = rasterizeTown(townModel, rows, cols);
-    return mapData;
+    const rasterized = rasterizeTownModel(townModel, rows, cols);
+
+    const tiles: MapTile[][] = rasterized.tileBiomeIds.map((row, y) =>
+        row.map((biomeId, x) => ({
+            x,
+            y,
+            biomeId,
+            discovered: true,
+            isPlayerCurrent: false,
+        }))
+    );
+
+    return {
+        gridSize: { rows, cols },
+        tiles,
+        activeSeededFeatures: rasterized.activeSeededFeatures,
+        pathDetails: rasterized.pathDetails,
+    };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -468,6 +468,8 @@ export interface MapTile {
 export interface MapData {
   gridSize: { rows: number; cols: number };
   tiles: MapTile[][]; // tiles[row][col]
+  activeSeededFeatures?: Array<{ x: number; y: number; config: SeededFeatureConfig; actualSize: number }>;
+  pathDetails?: PathDetails;
 }
 
 export interface GeminiLogEntry {
@@ -520,7 +522,8 @@ export type ActionType =
   | 'ADD_LOCATION_RESIDUE'
   | 'REMOVE_LOCATION_RESIDUE'
   | 'QUICK_TRAVEL'
-  | 'ENTER_VILLAGE';
+  | 'ENTER_VILLAGE'
+  | 'ENTER_TOWN';
   
 
 export enum DiscoveryType {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -426,7 +426,8 @@ export type ActionType =
   | 'CAST_SPELL'
   | 'USE_LIMITED_ABILITY'
   | 'LONG_REST'
-  | 'SHORT_REST';
+  | 'SHORT_REST'
+  | 'ENTER_TOWN';
 
 
 export enum DiscoveryType {

--- a/src/utils/submapUtils.ts
+++ b/src/utils/submapUtils.ts
@@ -9,7 +9,15 @@ import { LOCATIONS, STARTING_LOCATION_ID, BIOMES } from '../constants';
 import { biomeVisualsConfig, defaultBiomeVisuals } from '../config/submapVisualsConfig';
 
 // --- Hashing ---
-const simpleHash = (worldSeed: number, worldX: number, worldY: number, biomeSeedText: string, submapX: number, submapY: number, seedSuffix: string): number => {
+export const simpleHash = (
+    worldSeed: number,
+    worldX: number,
+    worldY: number,
+    biomeSeedText: string,
+    submapX: number,
+    submapY: number,
+    seedSuffix: string
+): number => {
     let h = 0;
     const str = `${worldSeed},${worldX},${worldY},${submapX},${submapY},${biomeSeedText},${seedSuffix}`;
     for (let i = 0; i < str.length; i++) {


### PR DESCRIPTION
## Summary
- Replace town rasterizer with richer `rasterizeTownModel` including roads, walls, gates, and path adjacency
- Centralize submap hashing and integrate rasterized town data in hooks and map service
- Extend `MapData` to carry seeded features and path details
- Add `ENTER_TOWN` action so dev menu can simulate entering a town and generate a map

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688dfafc5d54832fafa140c7a0d49649