### PR TITLE
chore: remove tailwind CDN and guard path nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,14 @@ For a complete index of all documentation, please see the [README Index](./docs/
 ### Core Stack
 *   **Framework**: **React** (v19) using modern features like hooks.
 *   **Language**: **TypeScript** for type safety.
-*   **Styling**: **Tailwind CSS** for utility-first styling. All custom styles are in `<style>` blocks in `index.html`.
-*   **Modules**: The app uses native **ES6 Modules**. The `index.html` file contains an `<script type="importmap">` which defines how modules like `react`, `@google/genai`, etc., are loaded directly from `esm.sh`. **There is no local `node_modules` folder or complex build tool like Webpack or Vite.**
+*   **Styling**: **Tailwind CSS** for utility-first styling, compiled with PostCSS via the `index.css` entry file.
+*   **Modules**: The app uses native **ES6 Modules** with Vite for development and build. The `index.html` file contains a `<script type="importmap">` which defines how modules like `react`, `@google/genai`, etc., can be loaded directly from `esm.sh`.
 *   **AI Integration**: The app uses the **`@google/genai`** SDK for all interactions with the Gemini models. This is a core, unchangeable requirement.
 
 ### Architectural Constraints (What I Can't Do)
 
 Because this is a client-side, static application without a traditional build pipeline, there are some hard limitations:
 *   **No Backend**: I cannot add a server, a database (like MySQL, MongoDB), or server-side languages (like Node.js, Python, PHP). All state must be managed on the client or saved to Local Storage.
-*   **No Build Tools**: I cannot introduce complex build systems (Webpack, Vite, Babel) or modify a `package.json` file. All dependencies must be available via the existing import-map structure from a CDN like `esm.sh`.
 *   **No New Top-Level Files**: I cannot add new files to the absolute root directory. New files should be placed in appropriate subdirectories (e.g., `src/components/`, `src/hooks/`).
 
 ### Architectural Possibilities (Thinking Outside the Box)
@@ -47,7 +46,7 @@ Mentioning these possibilities helps me understand that you're open to evolving 
 
 The project follows a component-based architecture with a clear separation of concerns.
 
-*   **`index.html`**: The main entry point. Loads Tailwind CSS, fonts, and the root React script. Contains the `importmap`.
+*   **`index.html`**: The main entry point. Links the compiled Tailwind CSS, loads fonts, and the root React script. Contains the `importmap`.
 *   **`index.tsx`**: Renders the `App` component into the DOM.
 *   **`src/`**: The main source code directory.
     *   **`App.tsx`**: The root React component, managing overall game state and logic. See [`src/App.README.md`](./src/App.README.md).

--- a/docs/AI_PROMPT_GUIDE.md
+++ b/docs/AI_PROMPT_GUIDE.md
@@ -19,15 +19,14 @@ To know what's possible, it helps to understand the application's technical land
 
 *   **Framework**: **React** (v19) using modern features like hooks.
 *   **Language**: **TypeScript** for type safety.
-*   **Styling**: **Tailwind CSS** for utility-first styling. All custom styles are in `<style>` blocks in `index.html`.
-*   **Modules**: The app uses native **ES6 Modules**. The `index.html` file contains an `<script type="importmap">` which defines how modules like `react`, `@google/genai`, etc., are loaded directly from `esm.sh`. **There is no local `node_modules` folder or complex build tool like Webpack or Vite.**
+*   **Styling**: **Tailwind CSS** for utility-first styling, compiled with PostCSS via the `index.css` entry file.
+*   **Modules**: The app uses native **ES6 Modules** with Vite for development and build. The `index.html` file contains a `<script type="importmap">` which defines how modules like `react`, `@google/genai`, etc., can be loaded directly from `esm.sh`.
 *   **AI Integration**: The app uses the **`@google/genai`** SDK for all interactions with the Gemini models. This is a core, unchangeable requirement.
 
 ### Architectural Constraints (What I Can't Do)
 
 Because this is a client-side, static application without a traditional build pipeline, there are some hard limitations:
 *   **No Backend**: I cannot add a server, a database (like MySQL, MongoDB), or server-side languages (like Node.js, Python, PHP). All state must be managed on the client or saved to Local Storage.
-*   **No Build Tools**: I cannot introduce complex build systems (Webpack, Vite, Babel) or modify a `package.json` file. All dependencies must be available via the existing import-map structure from a CDN like `esm.sh`.
 *   **No New Top-Level Files**: I cannot add new files to the absolute root directory. New files should be placed in appropriate subdirectories (e.g., `src/components/`, `src/hooks/`).
 
 ### Architectural Possibilities (Thinking Outside the Box)

--- a/docs/PROJECT_OVERVIEW.README.md
+++ b/docs/PROJECT_OVERVIEW.README.md
@@ -19,15 +19,14 @@ Welcome to the main documentation hub for the Aralia RPG project. This document 
 ### Core Stack
 *   **Framework**: **React** (v19) using modern features like hooks.
 *   **Language**: **TypeScript** for type safety.
-*   **Styling**: **Tailwind CSS** for utility-first styling. All custom styles are in `<style>` blocks in `index.html`.
-*   **Modules**: The app uses native **ES6 Modules**. The `index.html` file contains an `<script type="importmap">` which defines how modules like `react`, `@google/genai`, etc., are loaded directly from `esm.sh`. **There is no local `node_modules` folder or complex build tool like Webpack or Vite.**
+*   **Styling**: **Tailwind CSS** for utility-first styling, compiled with PostCSS via the `index.css` entry file.
+*   **Modules**: The app uses native **ES6 Modules** with Vite for development and build. The `index.html` file contains a `<script type="importmap">` which defines how modules like `react`, `@google/genai`, etc., can be loaded directly from `esm.sh`.
 *   **AI Integration**: The app uses the **`@google/genai`** SDK for all interactions with the Gemini models. This is a core, unchangeable requirement.
 
 ### Architectural Constraints (What I Can't Do)
 
 Because this is a client-side, static application without a traditional build pipeline, there are some hard limitations:
 *   **No Backend**: I cannot add a server, a database (like MySQL, MongoDB), or server-side languages (like Node.js, Python, PHP). All state must be managed on the client or saved to Local Storage.
-*   **No Build Tools**: I cannot introduce complex build systems (Webpack, Vite, Babel) or modify a `package.json` file. All dependencies must be available via the existing import-map structure from a CDN like `esm.sh`.
 *   **No New Top-Level Files**: I cannot add new files to the absolute root directory. New files should be placed in appropriate subdirectories (e.g., `src/components/`, `src/hooks/`).
 
 ### Architectural Possibilities (Thinking Outside the Box)
@@ -46,7 +45,7 @@ Mentioning these possibilities helps me understand that you're open to evolving 
 
 The project follows a component-based architecture with a clear separation of concerns.
 
-*   **`index.html`**: The main entry point. Loads Tailwind CSS, fonts, and the root React script. Contains the `importmap`.
+*   **`index.html`**: The main entry point. Links the compiled Tailwind CSS, loads fonts, and the root React script. Contains the `importmap`.
 *   **`index.tsx`**: Renders the `App` component into the DOM.
 *   **`src/`**: The main source code directory.
     *   **`App.tsx`**: The root React component, managing overall game state and logic. See [`src/App.README.md`](./src/App.README.md).

--- a/docs/improvements/04_externalize_css.md
+++ b/docs/improvements/04_externalize_css.md
@@ -81,8 +81,8 @@ Therefore, the new stylesheet **must** be placed in `/public` (e.g., `public/sty
             <meta charset="UTF-8">
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
             <title>Aralia RPG</title>
-            <!-- Tailwind CSS is loaded first to provide the base utility classes. -->
-            <script src="https://cdn.tailwindcss.com"></script>
+            <!-- Compiled Tailwind CSS is linked first to provide the base utility classes. -->
+            <link rel="stylesheet" href="/index.css">
             <!-- Font stylesheets are loaded next. -->
             <link rel="preconnect" href="https://fonts.googleapis.com">
             <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -123,11 +123,11 @@ Therefore, the new stylesheet **must** be placed in `/public` (e.g., `public/sty
     -   **Code Suggestion (Example for `docs/PROJECT_OVERVIEW.README.md`)**:
         -   **Before**:
             ```markdown
-            *   **Styling**: **Tailwind CSS** for utility-first styling. All custom styles are in `<style>` blocks in `index.html`.
+            *   **Styling**: **Tailwind CSS** for utility-first styling, compiled with PostCSS via the `index.css` entry file.
             ```
         -   **After**:
             ```markdown
-            *   **Styling**: **Tailwind CSS** for utility-first styling. All custom styles are in a dedicated stylesheet located at `public/styles.css`, which is linked from `index.html`.
+            *   **Styling**: **Tailwind CSS** for utility-first styling. All custom styles are in a dedicated stylesheet located at `index.css`, which is linked from `index.html`.
             ```
 
 ### Phase 5: Final Verification

--- a/index.html
+++ b/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Aralia RPG</title>
-    <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700;900&family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">

--- a/src/services/town-generator/topology.ts
+++ b/src/services/town-generator/topology.ts
@@ -1,7 +1,8 @@
 import { Point } from './geom';
 
+const EPSILON = 1e-6;
 function pointEquals(p1: Point, p2: Point): boolean {
-    return p1.x === p2.x && p1.y === p2.y;
+    return Math.abs(p1.x - p2.x) < EPSILON && Math.abs(p1.y - p2.y) < EPSILON;
 }
 import { Graph } from './graph';
 import { Model } from './model';
@@ -115,10 +116,18 @@ export class Topology {
 
     public buildPath(from: Point, to: Point, exclude: Node[] = []): Point[] | null {
         console.log(`buildPath called: From {x: ${from.x}, y: ${from.y}}, To {x: ${to.x}, y: ${to.y}}`);
-        const fromNode = this.findNodeByPoint(from);
-        const toNode = this.findNodeByPoint(to);
+        let fromNode = this.findNodeByPoint(from);
+        if (!fromNode) {
+            console.warn(`buildPath: fromNode not found for {x: ${from.x}, y: ${from.y}}. Attempting to register point.`);
+            fromNode = this.processPoint(from);
+        }
+        let toNode = this.findNodeByPoint(to);
+        if (!toNode) {
+            console.warn(`buildPath: toNode not found for {x: ${to.x}, y: ${to.y}}. Attempting to register point.`);
+            toNode = this.processPoint(to);
+        }
         if (!fromNode || !toNode) {
-            console.warn(`buildPath: fromNode or toNode is null. From: ${fromNode ? 'valid' : 'null'}, To: ${toNode ? 'valid' : 'null'}`);
+            console.warn(`buildPath: fromNode or toNode is still null after processing. From: ${fromNode ? 'valid' : 'null'}, To: ${toNode ? 'valid' : 'null'}`);
             return null;
         }
 


### PR DESCRIPTION
## Summary
- drop Tailwind CDN script and rely on compiled `index.css`
- document PostCSS-based styling and update related guides
- harden topology path builder with tolerant point match and node auto-registration

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e831ba758832f9720dc9050e38f1a